### PR TITLE
Made Schedule behave more appropriately

### DIFF
--- a/TigerHacks-App/TigerHacks-App/Views/Schedule/ScheduleViewController.swift
+++ b/TigerHacks-App/TigerHacks-App/Views/Schedule/ScheduleViewController.swift
@@ -38,6 +38,7 @@ class ScheduleViewController: UIViewController, UITableViewDelegate, UITableView
         dateFormatter.timeStyle = .short
         longDateFormatter.timeZone = TimeZone.current
         longDateFormatter.dateFormat = "MM/dd/yyyy"
+        setDay()
         loadSchedules()
         
         // Swipe To Change Day
@@ -104,11 +105,6 @@ class ScheduleViewController: UIViewController, UITableViewDelegate, UITableView
     }
     
 // MARK: - Default Starting Day
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(true)
-        setDay()
-    }
     
     func setDay() {
 


### PR DESCRIPTION
We want the schedule to load in on the day that the hackathon is on. However, it was doing that every time a user selected an event, which was annoying. Now it only sets the segmented control to the current day on original load, which makes more sense in my mind.

Basically I moved setDay() from viewWillAppear() to viewDidLoad()