### PR TITLE
Mentor Cells are no longer selectable

### DIFF
--- a/TigerHacks-App/TigerHacks-App/Views/Sponsors/SponsorsDetailViewController.swift
+++ b/TigerHacks-App/TigerHacks-App/Views/Sponsors/SponsorsDetailViewController.swift
@@ -162,6 +162,7 @@ class SponsorsDetailViewController: UIViewController, UITableViewDelegate, UITab
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "mentorCell", for: indexPath) as! MentorTableViewCell
         cell.delegate = self
+        cell.selectionStyle = .none
         
         if let mentor = mentorList?[indexPath.row] {
             cell.mentorNameLabel?.text = mentor.name


### PR DESCRIPTION
The cells for mentors are no longer selectable cause they didn't need to be. Just the contact button needs to be touchable.