### PR TITLE
Fixing the absence of mentors for sponsors by making it actually use …

### DIFF
--- a/TigerHacks-App/TigerHacks-App/Model/Model.swift
+++ b/TigerHacks-App/TigerHacks-App/Model/Model.swift
@@ -17,7 +17,6 @@ class Model {
     }
     // Hex code for colors: FDFAE5
 
-    var sponsors: [Sponsor]?
     var dayOneSchedule: [Event]?
     var dayTwoSchedule: [Event]?
     var dayThreeSchedule: [Event]?

--- a/TigerHacks-App/TigerHacks-App/Views/Sponsors/SponsorsDetailViewController.swift
+++ b/TigerHacks-App/TigerHacks-App/Views/Sponsors/SponsorsDetailViewController.swift
@@ -35,7 +35,6 @@ class SponsorsDetailViewController: UIViewController, UITableViewDelegate, UITab
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        loadMentors()
 
         // Label Initialization
 
@@ -73,17 +72,10 @@ class SponsorsDetailViewController: UIViewController, UITableViewDelegate, UITab
 
 // MARK: - Load Mentor Data
 
-    func loadMentors() {
-        if let titleText = titleText {
-            mentorList = Model.sharedInstance.sponsors?.first(where: {$0.name == titleText})?.mentors
-        }
-    }
-
     @objc func refresh(_ sender: Any) {
         Model.sharedInstance.fakeAPICall()
         let when = DispatchTime.now() + 0.7
         DispatchQueue.main.asyncAfter(deadline: when) {
-            self.loadMentors()
             self.refreshControl.endRefreshing()
             self.mentorTableView.reloadData()
         }


### PR DESCRIPTION
…the data sent in prepareforsegue. Sponsors data no longer stored in model. If we ever need this elsewhere in the app, this will need to change.