### PR TITLE
Added Clarifications to Event Notifications

### DIFF
--- a/TigerHacks-App/TigerHacks-App/Model/Event.swift
+++ b/TigerHacks-App/TigerHacks-App/Model/Event.swift
@@ -32,6 +32,13 @@ struct Event {
     }
 
     var request: UNNotificationRequest {
-        return UNNotificationRequest(identifier: self.title, content: self.content, trigger: self.trigger)
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeStyle = .short
+        
+        let tempContent = self.content
+        tempContent.subtitle = "\(dateFormatter.string(from: self.time)): \(self.content)"
+        tempContent.title = self.title + "in 15 minutes"
+    
+        return UNNotificationRequest(identifier: self.title, content: tempContent, trigger: self.trigger)
     }
 }


### PR DESCRIPTION
We now include the time in the body of the notification as such: "7:00PM: Come get Dinner from Chipotle"

We also include that its 15 minutes prior in the title of the notification as such: "Closing Ceremony in 15 minutes" (The "in 15 minutes" is temporarily appended to the end of every event's title before being added to the notification)